### PR TITLE
Updated listeningstation.dmm

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -12,11 +12,11 @@
 "ad" = (
 /obj/structure/fluff/railing/corner,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ae" = (
 /obj/structure/railing,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "af" = (
 /obj/structure/rack{
@@ -30,7 +30,6 @@
 	pixel_y = -1;
 	pixel_x = 8
 	},
-/obj/item/clothing/mask/gas/syndicate,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4;
 	icon_state = "bot_white"
@@ -51,7 +50,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ai" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -62,19 +61,19 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aj" = (
 /obj/structure/fluff/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ak" = (
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "al" = (
 /obj/structure/table,
@@ -88,7 +87,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "am" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -96,7 +98,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/red/corner,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "an" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -113,13 +115,13 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ao" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ap" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -144,9 +146,7 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ar" = (
 /obj/effect/turf_decal/siding/red/corner{
@@ -166,13 +166,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "as" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "at" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -181,7 +181,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -190,7 +190,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "av" = (
 /obj/machinery/light/small{
@@ -209,13 +209,8 @@
 /obj/item/pen{
 	pixel_x = 3
 	},
-/obj/item/multitool{
-	pixel_y = 4;
-	pixel_x = -5
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aw" = (
 /obj/structure/table,
@@ -229,7 +224,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ax" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -237,17 +235,19 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ay" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-33";
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/trimline/dark_red/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
+/obj/structure/filingcabinet,
+/obj/item/paper/fluff/ruins/listeningstation/reports/october,
+/obj/item/paper/fluff/ruins/listeningstation/reports/september,
+/obj/item/paper/fluff/ruins/listeningstation/reports/august,
+/obj/item/paper/fluff/ruins/listeningstation/reports/july,
+/obj/item/paper/fluff/ruins/listeningstation/reports/june,
+/obj/item/paper/fluff/ruins/listeningstation/reports/may,
+/obj/item/paper/fluff/ruins/listeningstation/reports/april,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "az" = (
 /turf/open/floor/wood{
@@ -264,13 +264,6 @@
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aB" = (
-/obj/item/storage/backpack/duffelbag/syndie/c20rbundle{
-	pixel_y = -1
-	},
-/obj/item/storage/backpack/duffelbag/syndie/c20rbundle{
-	pixel_y = 8
-	},
-/obj/structure/rack/shelf,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4;
 	icon_state = "bot_white"
@@ -278,9 +271,15 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
+/obj/structure/table,
+/obj/item/stamp/syndicate{
+	pixel_x = 9;
+	pixel_y = 9
 	},
+/obj/item/storage/book/bible/syndicate{
+	pixel_x = -13
+	},
+/turf/open/space/basic,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aC" = (
 /obj/structure/rack{
@@ -298,14 +297,15 @@
 	dir = 4;
 	icon_state = "bot_white"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aD" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck/syndicate,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aF" = (
 /turf/open/floor/glass/reinforced,
@@ -321,7 +321,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aI" = (
-/turf/open/floor/plasteel/dark/textured,
+/obj/structure/sign/poster/contraband/random,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aJ" = (
 /obj/effect/turf_decal/trimline/dark_red,
@@ -329,18 +330,18 @@
 	name = "Room 2";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/dark_red,
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications";
 	req_access_txt = "150"
 	},
-/obj/effect/turf_decal/trimline/dark_red,
-/turf/open/floor/plasteel,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aL" = (
 /obj/effect/turf_decal/siding/red{
@@ -360,25 +361,30 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/dark_red,
 /obj/machinery/door/airlock/hatch{
 	name = "E.V.A. Equipment";
 	req_access_txt = "150"
 	},
-/obj/effect/turf_decal/trimline/dark_red,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aN" = (
-/obj/structure/bookcase/random/adult,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/item/card/emagfake{
+	pixel_y = -5
+	},
+/obj/item/paper/fluff/ruins/listeningstation/briefing,
+/obj/item/clothing/accessory/ring/syntech,
+/obj/structure/table/wood/fancy/blackred,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aO" = (
 /obj/machinery/light/small{
@@ -404,6 +410,7 @@
 	dir = 4;
 	icon_state = "bot_white"
 	},
+/obj/item/inducer/sci/combat,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aP" = (
@@ -411,7 +418,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -426,7 +433,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aR" = (
 /obj/machinery/door/firedoor,
@@ -444,7 +451,7 @@
 	name = "Cafeteria";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -459,7 +466,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aT" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -470,7 +477,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aU" = (
 /obj/machinery/airalarm/syndicate{
@@ -489,7 +496,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -504,7 +511,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aW" = (
 /obj/machinery/light/small{
@@ -526,7 +533,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -541,7 +548,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aY" = (
 /obj/machinery/vending/snack/random{
@@ -554,7 +561,6 @@
 	dir = 4;
 	icon_state = "bot"
 	},
-/turf/open/floor/plasteel/dark/textured,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "aZ" = (
 /obj/structure/filingcabinet,
@@ -566,9 +572,8 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
+/obj/item/paper/monitorkey,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -583,26 +588,19 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bc" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bd" = (
-/obj/structure/bed/pod{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/item/bedsheet/syndie{
-	dir = 4;
-	pixel_y = 5
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "be" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -613,7 +611,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -624,7 +622,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -635,7 +633,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bh" = (
 /obj/machinery/vending/cola/random{
@@ -645,7 +643,6 @@
 	dir = 4;
 	icon_state = "bot"
 	},
-/turf/open/floor/plasteel/dark/textured,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bi" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -657,12 +654,9 @@
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bj" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bl" = (
 /obj/structure/sign/warning/securearea{
@@ -693,7 +687,7 @@
 	name = "Medical Care";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -703,7 +697,6 @@
 	name = "Private Quarters Access";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bq" = (
 /obj/structure/cable/yellow{
@@ -715,7 +708,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "br" = (
 /obj/structure/cable/yellow{
@@ -737,15 +729,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bs" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/blood/OMinus{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4;
 	icon_state = "bot_white"
@@ -753,7 +736,14 @@
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark/corner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/obj/machinery/vending/medical/syndicate_access/cybersun{
+	desc = "An advanced vendor that dispenses medical drugs, both recreational and medicinal. It's said to have been salvaged from an old decomissioned Cybersun Cruiser.";
+	name = "\improper SyndiMed ++"
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -763,18 +753,22 @@
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bu" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/structure/table/abductor,
+/turf/closed/mineral/random,
+/area/ruin/space)
 "bv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -791,7 +785,7 @@
 	dir = 4;
 	icon_state = "bot"
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "by" = (
 /obj/machinery/power/terminal{
@@ -828,23 +822,11 @@
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4;
-	icon_state = "bot_white"
-	},
-/obj/structure/closet/secure_closet/medical1{
-	req_access = null;
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bC" = (
 /obj/structure/cable,
@@ -853,13 +835,13 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/wrench,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bD" = (
 /obj/structure/table,
 /obj/item/melee/baton/stunsword/smithed,
 /obj/item/storage/box/lights/bulbs,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -888,9 +870,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/dark_red/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "bJ" = (
 /obj/docking_port/stationary{
@@ -933,7 +913,7 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "cz" = (
 /obj/structure/cable{
@@ -947,8 +927,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/red,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "cI" = (
 /obj/structure/cable{
@@ -960,15 +942,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "di" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
-/obj/structure/mirror{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/pool,
 /area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "dF" = (
 /obj/effect/turf_decal/siding/red{
@@ -977,7 +954,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "dH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1004,18 +981,17 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "dV" = (
 /obj/machinery/computer/message_monitor{
 	dir = 2
 	},
-/obj/item/paper/monitorkey,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "er" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -1048,23 +1024,19 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ey" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 14
+/obj/structure/toilet{
+	pixel_y = 18
 	},
-/obj/item/soap/syndie,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "eI" = (
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "eR" = (
 /obj/structure/closet/crate/bin,
@@ -1100,7 +1072,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"gC" = (
+/obj/item/bedsheet/syndie/double{
+	dir = 4
+	},
+/obj/structure/bed/double/pod{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "gU" = (
 /obj/structure/fluff/railing/corner{
@@ -1109,8 +1090,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"hc" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "hg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1119,7 +1106,7 @@
 	name = "Room 1";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "hj" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -1131,11 +1118,10 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "hy" = (
-/turf/open/floor/engine/vacuum,
-/area/ruin/space)
+/turf/open/floor/engine/vacuum)
 "hC" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -1183,7 +1169,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "iK" = (
 /obj/structure/table,
@@ -1217,9 +1203,6 @@
 /obj/item/storage/fancy/candle_box{
 	pixel_x = 4
 	},
-/obj/item/storage/book/bible/syndicate{
-	pixel_x = -13
-	},
 /obj/item/reagent_containers/glass/beaker/waterbottle/large,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -1230,7 +1213,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "lh" = (
 /obj/structure/grille,
@@ -1244,6 +1227,17 @@
 /obj/machinery/status_display/syndie,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"ma" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm{
+	pixel_x = 7
+	},
+/obj/item/storage/backpack/duffelbag/syndie/c20rbundle{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "mk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1252,24 +1246,14 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 1
 	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
+/obj/machinery/fax,
+/obj/item/paper/monitorkey,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "mD" = (
-/obj/structure/bed/pod{
-	dir = 1
-	},
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
-	dir = 4
-	},
-/obj/item/bedsheet/syndie{
-	dir = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/red,
+/obj/structure/bookcase/random/adult,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "mR" = (
 /obj/machinery/light/small{
@@ -1284,9 +1268,8 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 10
-	},
+/obj/item/paper/fluff/ruins/listeningstation/odd_report,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "mV" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
@@ -1295,18 +1278,24 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"mY" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/obj/machinery/sleeper/syndie,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "na" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/defibrillator/compact/combat,
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
+/obj/structure/table/optable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
 	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "nw" = (
 /obj/structure/cable/yellow{
@@ -1315,11 +1304,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ol" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "or" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1346,20 +1333,29 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "oL" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4;
-	icon_state = "bot_white"
-	},
 /obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus{
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/iv_drip/telescopic,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"pk" = (
+/obj/item/reagent_containers/rag/towel/random,
+/obj/item/reagent_containers/rag/towel/random,
+/obj/structure/bedsheetbin/towel,
+/obj/structure/table/wood,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "po" = (
-/obj/structure/toilet{
-	pixel_y = 18
-	},
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/bot,
+/obj/item/clothing/under/misc/bathrobe,
+/obj/item/clothing/under/misc/bathrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "pr" = (
@@ -1375,12 +1371,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "pR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/closet/crate/large,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/light/small,
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "qc" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/siding/red{
@@ -1389,13 +1383,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
-"qg" = (
+"qk" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/bluemoon/listeningstation/shower)
-"qk" = (
-/obj/structure/closet/crate/engineering/electrical,
+"qo" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	pixel_y = 14
+	},
+/obj/item/soap/syndie,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
+"qK" = (
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "qQ" = (
@@ -1414,20 +1419,29 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"qU" = (
+/obj/item/bedsheet/syndie/double{
+	dir = 1
+	},
+/obj/structure/bed/double/pod{
+	dir = 4
+	},
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rc" = (
 /obj/effect/turf_decal/trimline/dark_red/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
+/obj/structure/chair/comfy/black{
+	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rt" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/plasteel/dark/side,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1450,7 +1464,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "rx" = (
 /obj/structure/table/wood,
@@ -1470,7 +1484,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "sb" = (
 /obj/structure/closet/firecloset/full,
@@ -1484,12 +1498,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_red,
-/obj/machinery/door/airlock/hatch{
-	name = "Private Quarters Access";
-	req_access_txt = "150"
-	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "sm" = (
 /mob/living/simple_animal/pet/penguin/emperor{
@@ -1500,7 +1509,7 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ss" = (
 /obj/effect/turf_decal/siding/dark,
@@ -1514,7 +1523,7 @@
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/trimline/dark_red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "tn" = (
 /obj/structure/chair/office/dark{
@@ -1523,9 +1532,11 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 10
-	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"ty" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "tI" = (
 /turf/open/floor/mineral/plastitanium,
@@ -1541,9 +1552,6 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "tZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -1563,7 +1571,8 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "uM" = (
 /obj/machinery/firealarm{
@@ -1574,13 +1583,16 @@
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
 	},
+/obj/item/radio/headset/syndicate/alt,
+/obj/item/radio/headset/syndicate/alt,
 /turf/open/floor/circuit,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ve" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 2
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "vk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1619,7 +1631,7 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "vT" = (
 /obj/effect/turf_decal/siding/dark,
@@ -1638,7 +1650,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "wv" = (
 /obj/structure/cable/yellow{
@@ -1665,20 +1678,15 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xf" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm{
-	pixel_x = 7
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xJ" = (
 /obj/machinery/light/small,
@@ -1686,11 +1694,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/photocopier,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "xP" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm{
+	pixel_x = 7
+	},
+/obj/item/storage/backpack/duffelbag/syndie/c20rbundle{
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/blackred,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
 "yg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -1719,6 +1736,15 @@
 	dir = 4;
 	icon_state = "bot_white"
 	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 13
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "yC" = (
@@ -1742,7 +1768,18 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"zG" = (
+/obj/effect/turf_decal/trimline/dark_red,
+/obj/machinery/door/airlock/hatch{
+	name = "Private Quarters Access";
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "zT" = (
 /turf/open/floor/mineral/plastitanium/red,
@@ -1750,6 +1787,10 @@
 "Am" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/rag,
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_x = 10;
+	pixel_y = -10
+	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"
 	},
@@ -1775,16 +1816,16 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "AX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "BE" = (
 /obj/structure/cable{
@@ -1795,12 +1836,16 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
-"BZ" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium/red,
+"BS" = (
+/obj/machinery/defibrillator_mount,
+/turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"BZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Cd" = (
 /obj/item/radio/intercom{
 	freerange = 1;
@@ -1810,33 +1855,46 @@
 /obj/machinery/computer/secure_data/syndie{
 	dir = 4
 	},
-/obj/structure/railing,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ce" = (
 /obj/machinery/vending/donksofttoyvendor{
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Cf" = (
 /obj/structure/fluff/railing/corner{
 	dir = 4
 	},
-/obj/structure/filingcabinet,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4;
 	icon_state = "bot_white"
 	},
-/obj/item/paper/fluff/ruins/listeningstation/odd_report,
-/turf/open/floor/plasteel/dark,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"Ck" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
+	},
+/obj/structure/rack/shelf,
+/obj/item/mod/control/pre_equipped/syndicate_empty{
+	icon_state = "security-control";
+	pixel_y = -3;
+	pixel_x = 3
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "De" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -1869,18 +1927,24 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "DF" = (
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "DJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ea" = (
-/turf/open/floor/plasteel,
+/obj/structure/table/wood/fancy/blackred,
+/obj/item/paper_bin,
+/obj/item/pen/survival,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ew" = (
 /obj/effect/turf_decal/siding/red{
@@ -1889,7 +1953,7 @@
 /obj/effect/turf_decal/trimline/dark_red/corner,
 /obj/effect/turf_decal/siding/red/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "EU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1905,7 +1969,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ff" = (
 /obj/effect/turf_decal/siding/dark{
@@ -1929,15 +1993,12 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "FX" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/sleeper/syndie{
-	dir = 8
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Gr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -1953,7 +2014,7 @@
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "GB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1969,7 +2030,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "GY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1979,22 +2040,26 @@
 	pixel_y = 5
 	},
 /obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_x = 10;
+	pixel_y = -10
+	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Hf" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/shower{
+	pixel_y = 14
 	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/structure/curtain,
+/obj/item/soap/syndie,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Hq" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -2014,27 +2079,29 @@
 	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "HH" = (
-/obj/structure/table/wood,
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/ammo_box/magazine/m10mm{
-	pixel_x = 7
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "HU" = (
 /obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/effect/spawner/lootdrop/three_course_meal{
+	pixel_x = 10;
+	pixel_y = -10
+	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "HW" = (
-/obj/machinery/light/small,
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "HX" = (
@@ -2076,7 +2143,20 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"IS" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
+	},
+/obj/item/mod/module/jetpack/advanced,
+/obj/item/mod/module/storage{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/structure/rack/shelf,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Jc" = (
 /obj/structure/table/reinforced,
@@ -2089,11 +2169,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4;
 	icon_state = "bot_white"
-	},
-/obj/item/mod/control/pre_equipped/syndicate_empty{
-	icon_state = "security-control";
-	pixel_y = -3;
-	pixel_x = 3
 	},
 /obj/item/mod/control/pre_equipped/syndicate_empty{
 	icon_state = "security-control";
@@ -2121,21 +2196,20 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "JY" = (
 /obj/structure/statue/bronze/marx,
-/turf/open/floor/engine/vacuum,
-/area/ruin/space)
+/turf/open/floor/engine/vacuum)
 "Kf" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 4;
-	flags_1 = 2
+	dir = 4
 	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Kq" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/plasteel,
+/obj/item/storage/photo_album,
+/obj/structure/table/wood/fancy/blackred,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ks" = (
 /obj/structure/table/wood,
@@ -2149,12 +2223,18 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Kw" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/obj/structure/closet/secure_closet/medical1{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "KB" = (
 /obj/structure/chair/stool,
@@ -2174,7 +2254,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "KF" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -2183,7 +2263,11 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 10
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"KT" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "KX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2194,7 +2278,11 @@
 	dir = 2;
 	icon_state = "half_stairs_darkfull"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/item/kirbyplants{
+	icon_state = "plant-33";
+	pixel_y = 6
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Lu" = (
 /obj/machinery/computer/arcade/tetris{
@@ -2210,7 +2298,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "LL" = (
 /obj/structure/table,
@@ -2233,25 +2321,15 @@
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "LV" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/machinery/pool/controller,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Md" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 13
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = -3
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/cell_charger_multi,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Mq" = (
@@ -2301,7 +2379,7 @@
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "NJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2310,7 +2388,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/red/corner,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Ow" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -2337,9 +2415,11 @@
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "OQ" = (
-/obj/structure/closet/crate/engineering,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Pd" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2354,11 +2434,15 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Pl" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/plasteel/dark/textured,
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "PB" = (
 /obj/effect/turf_decal/trimline/dark_red,
@@ -2366,37 +2450,38 @@
 	name = "Restroom";
 	req_access_txt = "150"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "PW" = (
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/structure/filingcabinet,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4;
 	icon_state = "bot_white"
 	},
-/obj/item/paper/fluff/ruins/listeningstation/reports/april,
-/obj/item/paper/fluff/ruins/listeningstation/reports/may,
-/obj/item/paper/fluff/ruins/listeningstation/reports/june,
-/obj/item/paper/fluff/ruins/listeningstation/reports/july,
-/obj/item/paper/fluff/ruins/listeningstation/reports/august,
-/obj/item/paper/fluff/ruins/listeningstation/reports/september,
-/obj/item/paper/fluff/ruins/listeningstation/reports/october,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/side{
+/obj/structure/railing,
+/obj/machinery/computer/camera_advanced{
 	dir = 4
 	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Qe" = (
-/obj/item/paper/fluff/ruins/listeningstation/briefing,
-/obj/structure/table/wood,
-/obj/item/clothing/accessory/ring/syntech,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Qj" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/pool/ladder{
+	dir = 2;
+	pixel_y = 17
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Qm" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/stripes/corner{
@@ -2407,7 +2492,13 @@
 /obj/item/melee/classic_baton/telescopic/contractor_baton,
 /obj/item/melee/classic_baton/telescopic/contractor_baton,
 /obj/item/storage/box/handcuffs,
-/turf/open/floor/plasteel/dark/textured,
+/obj/item/storage/book/bible/syndicate{
+	pixel_x = -13
+	},
+/obj/item/storage/book/bible/syndicate{
+	pixel_x = -13
+	},
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Qu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -2431,18 +2522,20 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "QP" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 4;
-	flags_1 = 2
+	dir = 4
 	},
 /turf/open/floor/wood{
 	icon_state = "large_wood"
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Rf" = (
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "RA" = (
 /obj/machinery/light/small,
 /obj/machinery/airalarm/syndicate{
@@ -2452,15 +2545,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/line,
 /obj/machinery/computer/operating{
 	dir = 1;
 	name = "Robotics Operating Computer"
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
 	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "RY" = (
 /obj/machinery/computer/med_data/syndie{
@@ -2471,14 +2565,12 @@
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "So" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/red,
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "SU" = (
 /obj/effect/turf_decal/siding/red/corner{
@@ -2496,7 +2588,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "SV" = (
 /obj/structure/closet{
@@ -2528,13 +2620,10 @@
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/obj/item/storage/photo_album,
 /obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4;
-	icon_state = "bot_white"
-	},
-/turf/open/floor/plasteel/dark/textured,
+/obj/item/melee/bokken,
+/obj/item/melee/bokken,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "SY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -2571,8 +2660,18 @@
 	pixel_y = 40;
 	pixel_x = 26
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Ub" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/pool/drain{
+	pixel_x = -17;
+	pixel_y = 17
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Ue" = (
 /obj/item/kirbyplants/hedge{
 	anchored = 1
@@ -2580,17 +2679,17 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Vo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/pool/filter{
+	pixel_y = -17
 	},
-/turf/open/floor/plasteel/dark/textured,
-/area/ruin/space/has_grav/bluemoon/listeningstation)
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Vr" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 10
 	},
 /obj/effect/turf_decal/siding/red,
-/turf/open/floor/plasteel/dark/textured,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "VC" = (
 /obj/machinery/button/door{
@@ -2610,55 +2709,67 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"VD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/pool/drain{
+	pixel_x = -17;
+	pixel_y = 17
+	},
+/obj/machinery/light/small,
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "VM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
-"Wi" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+"Wb" = (
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck/syndicate,
+/obj/item/multitool{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Wi" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/mirror{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "Wr" = (
-/obj/structure/rack/shelf,
-/obj/item/mod/module/storage{
-	pixel_x = 2;
-	pixel_y = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4;
+	icon_state = "bot_white"
 	},
 /obj/item/mod/module/storage{
 	pixel_x = -5;
 	pixel_y = 6
 	},
-/obj/item/mod/module/flashlight{
-	pixel_x = 3;
-	pixel_y = -8
-	},
-/obj/item/mod/module/flashlight{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4;
-	icon_state = "bot_white"
-	},
+/obj/item/mod/module/jetpack/advanced,
+/obj/structure/rack/shelf,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Xf" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4;
-	icon_state = "bot_white"
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/defibrillator/compact/combat,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "Xj" = (
 /obj/structure/cable/yellow{
@@ -2681,7 +2792,7 @@
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "XP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/blackred,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "XT" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -2701,14 +2812,8 @@
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "YM" = (
-/obj/structure/table/wood,
-/obj/item/radio/headset/syndicate/alt,
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/item/radio/headset/syndicate/alt,
-/obj/item/card/emagfake{
-	pixel_y = -5
 	},
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
@@ -2718,8 +2823,20 @@
 	icon_state = "plant-27";
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
+"Zk" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/bluemoon/listeningstation)
+"ZX" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/turf/open/pool,
+/area/ruin/space/has_grav/bluemoon/listeningstation/shower)
 "ZY" = (
 /obj/machinery/vending/clothing{
 	default_price = 0;
@@ -2728,7 +2845,7 @@
 	onstation = 0
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 "ZZ" = (
 /obj/machinery/status_display{
@@ -2740,9 +2857,6 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
 	},
 /area/ruin/space/has_grav/bluemoon/listeningstation)
 
@@ -3113,7 +3227,7 @@ ab
 ab
 ab
 ab
-ab
+bu
 aa
 aa
 aa
@@ -3150,11 +3264,11 @@ ab
 ab
 ab
 ab
+bu
 ab
 ab
 ab
-aa
-aa
+ab
 aa
 aa
 aa
@@ -3183,17 +3297,17 @@ GY
 wV
 HU
 ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
+ag
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
 aa
 aa
 aa
@@ -3221,18 +3335,18 @@ aL
 ar
 KF
 ag
+qU
+xP
+ty
+ag
+ty
+ma
+gC
+ag
 ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
 aa
 aa
 aa
@@ -3259,20 +3373,20 @@ aF
 dF
 hj
 ag
+Qe
+Qe
+Qe
+ag
+Qe
+Qe
+Qe
+ag
 ab
 ab
 ab
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 aa
 aa
 aa
@@ -3297,21 +3411,21 @@ aF
 qc
 GN
 ag
+KT
+Qe
+Ea
 ag
-ag
-ag
-ag
-ag
-ag
-ag
+KT
+Qe
+Ea
 ag
 ab
 ab
 ab
-aa
-aa
-aa
-aa
+ab
+ab
+ab
+ab
 aa
 aa
 aa
@@ -3342,15 +3456,15 @@ Qu
 So
 HH
 bd
-ag
+qk
+qk
+qk
+qk
+qk
+qk
+qk
+qk
 ab
-ab
-ab
-ab
-aa
-aa
-aa
-aa
 aa
 aa
 "}
@@ -3377,19 +3491,19 @@ ve
 XP
 xJ
 Gr
-XP
+bj
 XP
 wa
-ag
+qk
+qo
+Wi
+pk
+ZX
+di
+OQ
+qk
 ab
 ab
-ab
-ab
-ab
-ab
-aa
-aa
-aa
 aa
 "}
 (18,1,1) = {"
@@ -3403,31 +3517,31 @@ ag
 ag
 ag
 ag
-ac
-qQ
 aI
-Kw
+qQ
+tI
+aD
 ac
 ag
 ag
 ag
 ag
-ag
+zG
 sg
 bw
+ag
 aJ
 ag
-ag
-qg
-qg
-qg
-qg
+qk
+Hf
+HW
+LV
+DF
+Rf
+VD
+qk
 ab
 ab
-ab
-ab
-aa
-aa
 aa
 "}
 (19,1,1) = {"
@@ -3443,11 +3557,11 @@ aq
 aZ
 ag
 bb
-aI
+tI
 aD
 ag
 Pl
-Pl
+ik
 SV
 ag
 YM
@@ -3455,18 +3569,18 @@ OD
 cl
 yg
 ik
-Wi
-qg
+ik
+qk
 po
-di
-qg
+HW
+HW
+Qj
+Rf
+ol
+qk
 ab
 ab
 ab
-ab
-ab
-aa
-aa
 "}
 (20,1,1) = {"
 aa
@@ -3474,34 +3588,34 @@ aa
 lh
 lh
 mR
+tI
 ak
-ae
 Cf
-aI
+tI
 ay
 lx
 bb
-aI
-bj
+tI
+aD
 ag
 bv
 ik
 ik
 ag
-Qe
+ik
 OD
 aA
 ik
 ik
-Ea
+ik
 PB
-xP
 HW
-qg
-ab
-ab
-ab
-ab
+HW
+HW
+DF
+Rf
+pR
+qk
 ab
 ab
 ab
@@ -3532,14 +3646,14 @@ XY
 ik
 ik
 YZ
-qg
+qk
 ey
-xP
-qg
-ab
-ab
-ab
-ab
+HW
+Vo
+hc
+BZ
+Ub
+qk
 ab
 ab
 ab
@@ -3550,11 +3664,11 @@ aa
 lh
 dV
 sm
-aI
-DF
+tI
+tI
 KY
-Vo
-rc
+yY
+Wb
 ag
 aR
 sD
@@ -3570,14 +3684,14 @@ Ce
 Nz
 Gw
 ZY
-qg
-qg
-qg
-qg
-ag
-ab
-ab
-ab
+qk
+qk
+qk
+qk
+qk
+qk
+qk
+qk
 ab
 ab
 ab
@@ -3592,7 +3706,7 @@ xb
 ad
 ai
 at
-rc
+qK
 ag
 aS
 Vr
@@ -3612,10 +3726,10 @@ ag
 Dr
 tI
 Ji
+Ck
+IS
+Wr
 ag
-ab
-ab
-ab
 ab
 ab
 ab
@@ -3647,13 +3761,13 @@ yh
 Jn
 Md
 ow
-LV
-BZ
-Wr
+tI
+tI
+tI
+tI
+tI
+tI
 ag
-ab
-ab
-ab
 ab
 ab
 aa
@@ -3799,7 +3913,7 @@ Ue
 js
 Ks
 vT
-ol
+zT
 tZ
 Pd
 Jv
@@ -3826,9 +3940,9 @@ aY
 bh
 ag
 rt
-bu
+zT
 oL
-ag
+BS
 yC
 SY
 er
@@ -3837,8 +3951,8 @@ AC
 cg
 ju
 vT
-OQ
-yY
+zT
+tZ
 ag
 ag
 ag
@@ -3864,7 +3978,7 @@ ag
 ag
 ag
 FX
-Hf
+zT
 Xf
 ag
 Tx
@@ -3875,8 +3989,8 @@ Ue
 wT
 es
 vT
-qk
-pR
+zT
+tZ
 ag
 ab
 ab
@@ -3901,9 +4015,9 @@ ag
 ab
 ab
 ag
-ag
-ag
-ag
+mY
+Zk
+Kw
 ag
 ag
 ag
@@ -3938,11 +4052,11 @@ ag
 ag
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+ag
+ag
+ag
+ag
+ag
 ab
 ab
 ab
@@ -3975,16 +4089,16 @@ ag
 ab
 ab
 ab
-aa
-aa
-aa
 ab
 ab
 ab
 ab
 ab
 ab
-aa
+ab
+ab
+ab
+ab
 ab
 ab
 ab
@@ -4013,20 +4127,20 @@ aa
 aa
 aa
 aa
+ab
+ab
+ab
+ab
+ab
+ab
 aa
 aa
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+ab
+ab
 ab
 aa
 ab


### PR DESCRIPTION
Описание:
В целом небольшой ремап аванпоста прослушки. Расширил и сделал более привлекательными дормы офокомов. Улучшил пространство корридора ведущего от дорм в пространство бара. Добавил туда спорт инвентарь в виде тренажёров и двух деревянных боккенов (скрестить мечи :) ) Улучшил сам мостик прослушки. добавил туда 2е место для работы что бы 2 Офкома могли работать одновременно. Расширил мед блок и добавил туда вендомат с медициной. Расширил душевые и внимание: Джакузи! Теперь офкомы могут отдохнуть с комфортом. Так же добавил небольшие плюшки по экипировке и изменил расположении экипировки для удобства самих офкомов.
- [x] Этот пулл-реквест готов к тест-мерджу.
Причина изменений:
Теперь прослушка не выглядит как вахта на пару дней. Там теперь полноценно можно жить работать или отдыхать. И при желании вылечить людей.


P.S. \UwU/